### PR TITLE
adjust package name for id3info

### DIFF
--- a/mussort
+++ b/mussort
@@ -882,7 +882,7 @@ sub depError
 	my $install = shift;
 	my $recommended = shift;
 	my $debPackages = {
-			id3info => 'libid3-dev',
+			id3info => 'libid3-tools',
 			id3v2 => 'id3v2',
 			ogginfo => 'vorbis-tools',
 			'Audio::File' => 'libaudio-file-perl',


### PR DESCRIPTION
I noticed that mussort lists `libid3-dev` as the Debian/Ubuntu package for `id3info` (https://github.com/zerodogg/mussort/blob/master/mussort#L885). However, it seems that this file is contained in the `libid3-tools` package instead:
```
$ apt-file search id3info
libid3-tools: /usr/bin/id3info
libid3-tools: /usr/share/man/man1/id3info.1.gz
```
Note that installing `libid3-dev` also pulls in `libid3-tools` -- but only if installation of recommended packages is enabled. If it's not, `id3info` will simply be missing. I propose to directly ask the user to install `libid3-tools`.